### PR TITLE
assume false if yaml_node is NULL

### DIFF
--- a/src/yaml.c
+++ b/src/yaml.c
@@ -130,6 +130,10 @@ mrb_value
 node_to_value(mrb_state *mrb,
   yaml_document_t *document, yaml_node_t *node)
 {
+  /* YAML will return a NULL node if the input was empty */
+  if (!node)
+    return mrb_false_value();
+
   switch (node->type)
   {
     case YAML_SCALAR_NODE:

--- a/test/yaml.rb
+++ b/test/yaml.rb
@@ -1,6 +1,10 @@
 
 # YAML::load
 
+assert('YAML load empty') do
+	YAML.load('') == false
+end
+
 assert('YAML load scalar') do
 	YAML.load('foo') == 'foo'
 end


### PR DESCRIPTION
This was a bug that occured when `YAML.load('')` was called.
