### PR TITLE
Added support for proper types

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,28 @@
 
 mruby-yaml wraps [libyaml](http://pyyaml.org/wiki/LibYAML) and therefore complies with the YAML 1.1 standard. File IO is not supported, as this would create a dependency on other mruby gems.
 
+### Defines
+| Name                             | Default | Description                    |
+| -------------------------------- | ------- | ------------------------------ |
+| MRUBY_YAML_NULL                  | true    | enables `null`, `Null`, `NULL` |
+| MRUBY_YAML_BOOLEAN_ON            | true    | enables `on`, `On`, `ON`       |
+| MRUBY_YAML_BOOLEAN_YES           | true    | enables `yes`, `Yes`, `YES`    |
+| MRUBY_YAML_BOOLEAN_SHORTHAND_YES | true    | enables `y`, `Y`               |
+| MRUBY_YAML_BOOLEAN_OFF           | true    | enables `off`, `Off`, `OFF`    |
+| MRUBY_YAML_BOOLEAN_NO            | true    | enables `no`, `No`, `NO`       |
+| MRUBY_YAML_BOOLEAN_SHORTHAND_NO  | true    | enables `n`, `N`               |
+
+If you need to check if a feature is supported at runtime, replace `MRUBY_YAML_` with `SUPPORT_` for the runtime equivalent.
+
+#### EG.
+```ruby
+if YAML::SUPPORT_NULL
+  YAML.load('null') == nil
+else  
+  YAML.load('null') == 'null'
+end
+```
+
 ### Documentation
 
 #### `YAML.load(yaml_str)`

--- a/src/yaml.c
+++ b/src/yaml.c
@@ -16,6 +16,28 @@
 
 #define streql(a, b) (strcmp(a, b) == 0)
 
+#ifndef MRUBY_YAML_NULL
+#  define MRUBY_YAML_NULL 1
+#endif
+#ifndef MRUBY_YAML_BOOLEAN_ON
+#  define MRUBY_YAML_BOOLEAN_ON 1
+#endif
+#ifndef MRUBY_YAML_BOOLEAN_YES
+#  define MRUBY_YAML_BOOLEAN_YES 1
+#endif
+#ifndef MRUBY_YAML_BOOLEAN_SHORTHAND_YES
+#  define MRUBY_YAML_BOOLEAN_SHORTHAND_YES 1
+#endif
+#ifndef MRUBY_YAML_BOOLEAN_OFF
+#  define MRUBY_YAML_BOOLEAN_OFF 1
+#endif
+#ifndef MRUBY_YAML_BOOLEAN_NO
+#  define MRUBY_YAML_BOOLEAN_NO 1
+#endif
+#ifndef MRUBY_YAML_BOOLEAN_SHORTHAND_NO
+#  define MRUBY_YAML_BOOLEAN_SHORTHAND_NO 1
+#endif
+
 void mrb_mruby_yaml_gem_init(mrb_state *mrb);
 void mrb_mruby_yaml_gem_final(mrb_state *mrb);
 
@@ -155,19 +177,38 @@ node_to_value_with_aliases(mrb_state *mrb,
 
         if (use_scalar_aliases) {
           /* Check if it is a null http://yaml.org/type/null.html */
-          if (streql("nil", str) || streql("null", str) || streql("Null", str) ||
-              streql("NULL", str) || streql("", str)) {
+          if (streql("nil", str) || streql("", str)
+          #if MRUBY_YAML_NULL
+            || streql("null", str) || streql("Null", str) || streql("NULL", str)
+          #endif
+            ) {
             return mrb_nil_value();
           /* Check if it is a Boolean http://yaml.org/type/bool.html */
-          } else if (streql("true", str) || streql("True", str) || streql("TRUE", str) ||
-              streql("yes", str) || streql("Yes", str) || streql("YES", str) ||
-              streql("on", str) || streql("On", str) || streql("ON", str) ||
-              streql("y", str) || streql("Y", str)) {
+          } else if (
+            streql("true", str) || streql("True", str) || streql("TRUE", str)
+          #if MRUBY_YAML_BOOLEAN_ON
+            || streql("on", str) || streql("On", str) || streql("ON", str)
+          #endif
+          #if MRUBY_YAML_BOOLEAN_YES
+            || streql("yes", str) || streql("Yes", str) || streql("YES", str)
+          #endif
+          #if MRUBY_YAML_BOOLEAN_SHORTHAND_YES
+            || streql("y", str) || streql("Y", str)
+          #endif
+            ) {
             return mrb_true_value();
-          } else if (streql("false", str) || streql("False", str) ||
-              streql("FALSE", str) || streql("off", str) || streql("Off", str) ||
-              streql("OFF", str) || streql("no", str) || streql("No", str) ||
-              streql("NO", str) || streql("n", str) || streql("N", str)) {
+          } else if (
+            streql("false", str) || streql("False", str) || streql("FALSE", str)
+          #if MRUBY_YAML_BOOLEAN_OFF
+            || streql("off", str) || streql("Off", str) || streql("OFF", str)
+          #endif
+          #if MRUBY_YAML_BOOLEAN_NO
+            || streql("no", str) || streql("No", str)  || streql("NO", str)
+          #endif
+          #if MRUBY_YAML_BOOLEAN_SHORTHAND_NO
+            || streql("n", str) || streql("N", str)
+          #endif
+            ) {
             return mrb_false_value();
           }
         }
@@ -319,7 +360,7 @@ int value_to_node(mrb_state *mrb,
       if (mrb_nil_p(value)) {
         /* http://yaml.org/type/null.html
            Canonical form */
-        value = mrb_str_new_cstr(mrb, "~");
+        value = mrb_str_new_lit(mrb, "~");
       } else {
         /* Equivalent to `obj = obj#to_s` */
         value = mrb_obj_as_string(mrb, value);
@@ -352,6 +393,14 @@ mrb_mruby_yaml_gem_init(mrb_state *mrb)
   struct RClass *klass = mrb_define_module(mrb, "YAML");
   mrb_define_class_method(mrb, klass, "load", mrb_yaml_load, ARGS_REQ(1));
   mrb_define_class_method(mrb, klass, "dump", mrb_yaml_dump, ARGS_REQ(1));
+
+  mrb_define_const(mrb, klass, "SUPPORT_NULL", mrb_bool_value(MRUBY_YAML_NULL));
+  mrb_define_const(mrb, klass, "SUPPORT_BOOLEAN_ON", mrb_bool_value(MRUBY_YAML_BOOLEAN_ON));
+  mrb_define_const(mrb, klass, "SUPPORT_BOOLEAN_YES", mrb_bool_value(MRUBY_YAML_BOOLEAN_YES));
+  mrb_define_const(mrb, klass, "SUPPORT_BOOLEAN_SHORTHAND_YES", mrb_bool_value(MRUBY_YAML_BOOLEAN_SHORTHAND_YES));
+  mrb_define_const(mrb, klass, "SUPPORT_BOOLEAN_OFF", mrb_bool_value(MRUBY_YAML_BOOLEAN_OFF));
+  mrb_define_const(mrb, klass, "SUPPORT_BOOLEAN_NO", mrb_bool_value(MRUBY_YAML_BOOLEAN_NO));
+  mrb_define_const(mrb, klass, "SUPPORT_BOOLEAN_SHORTHAND_NO", mrb_bool_value(MRUBY_YAML_BOOLEAN_SHORTHAND_NO));
 }
 
 

--- a/src/yaml.c
+++ b/src/yaml.c
@@ -28,6 +28,10 @@ typedef struct yaml_write_data_t
 int yaml_write_handler(void *data, unsigned char *buffer, size_t size);
 static void raise_parser_problem(mrb_state *mrb, yaml_parser_t *parser);
 
+static mrb_value node_to_value_with_aliases(mrb_state *mrb,
+  yaml_document_t *document, yaml_node_t *node, int use_scalar_aliases);
+static mrb_value node_to_value_key(mrb_state *mrb,
+  yaml_document_t *document, yaml_node_t *node);
 static mrb_value node_to_value(mrb_state *mrb,
   yaml_document_t *document, yaml_node_t *node);
 static int value_to_node(mrb_state *mrb,
@@ -40,36 +44,36 @@ mrb_yaml_load(mrb_state *mrb, mrb_value self)
   yaml_parser_t parser;
   yaml_document_t document;
   yaml_node_t *root;
-  
+
   mrb_value yaml_str;
   mrb_value result;
-  
+
   /* Extract arguments */
   mrb_get_args(mrb, "S", &yaml_str);
-  
+
   /* Initialize the YAML parser */
   yaml_parser_initialize(&parser);
   yaml_parser_set_input_string(&parser,
     (unsigned char *) RSTRING_PTR(yaml_str), RSTRING_LEN(yaml_str));
-  
+
   /* Load the document */
   yaml_parser_load(&parser, &document);
-  
+
   /* Error handling */
   if (parser.error != YAML_NO_ERROR)
   {
     raise_parser_problem(mrb, &parser);
     return mrb_nil_value();
   }
-  
+
   /* Convert the root node to an MRuby value */
   root = yaml_document_get_root_node(&document);
   result = node_to_value(mrb, &document, root);
-  
+
   /* Clean up */
   yaml_document_delete(&document);
   yaml_parser_delete(&parser);
-  
+
   return result;
 }
 
@@ -79,33 +83,33 @@ mrb_yaml_dump(mrb_state *mrb, mrb_value self)
 {
   yaml_emitter_t emitter;
   yaml_document_t document;
-  
+
   mrb_value root;
   yaml_write_data_t write_data;
-  
+
   /* Extract arguments */
   mrb_get_args(mrb, "o", &root);
-  
+
   /* Build the document */
   yaml_document_initialize(&document, NULL, NULL, NULL, 0, 0);
   value_to_node(mrb, &document, root);
-  
+
   /* Initialize the emitter */
   yaml_emitter_initialize(&emitter);
-  
+
   write_data.mrb = mrb;
   write_data.str = mrb_str_new(mrb, NULL, 0);
   yaml_emitter_set_output(&emitter, &yaml_write_handler, &write_data);
-  
+
   /* Dump the document */
   yaml_emitter_open(&emitter);
   yaml_emitter_dump(&emitter, &document);
   yaml_emitter_close(&emitter);
-  
+
   /* Clean up */
   yaml_emitter_delete(&emitter);
   yaml_document_delete(&document);
-  
+
   return write_data.str;
 }
 
@@ -123,15 +127,14 @@ void raise_parser_problem(mrb_state *mrb, yaml_parser_t *parser)
   mrb_value problem_line = mrb_fixnum_value(parser->problem_mark.line);
   mrb_value problem_col = mrb_fixnum_value(parser->problem_mark.column);
   mrb_value problem_str = mrb_str_new_cstr(mrb, parser->problem);
-  
+
   mrb_raisef(mrb, E_RUNTIME_ERROR, "%S at line %S column %S",
     problem_str, problem_line, problem_col);
 }
 
-
 mrb_value
-node_to_value(mrb_state *mrb,
-  yaml_document_t *document, yaml_node_t *node)
+node_to_value_with_aliases(mrb_state *mrb,
+  yaml_document_t *document, yaml_node_t *node, int use_scalar_aliases)
 {
   /* YAML will return a NULL node if the input was empty */
   if (!node)
@@ -148,21 +151,25 @@ node_to_value(mrb_state *mrb,
 
       /* if node is a YAML_PLAIN_SCALAR_STYLE */
       if (node->data.scalar.style == YAML_PLAIN_SCALAR_STYLE) {
-        /* Check if it is a null http://yaml.org/type/null.html */
-        if (streql("nil", str) || streql("null", str) || streql("Null", str) ||
-            streql("NULL", str) || streql("~", str) || streql("", str)) {
-          return mrb_nil_value();
-        /* Check if it is a Boolean http://yaml.org/type/bool.html */
-        } else if (streql("true", str) || streql("True", str) || streql("TRUE", str) ||
-            streql("yes", str) || streql("Yes", str) || streql("YES", str) ||
-            streql("on", str) || streql("On", str) || streql("ON", str) ||
-            streql("y", str) || streql("Y", str)) {
-          return mrb_true_value();
-        } else if (streql("false", str) || streql("False", str) ||
-            streql("FALSE", str) || streql("off", str) || streql("Off", str) ||
-            streql("OFF", str) || streql("no", str) || streql("No", str) ||
-            streql("NO", str) || streql("n", str) || streql("N", str)) {
-          return mrb_false_value();
+        if (streql("~", str)) return mrb_nil_value();
+
+        if (use_scalar_aliases) {
+          /* Check if it is a null http://yaml.org/type/null.html */
+          if (streql("nil", str) || streql("null", str) || streql("Null", str) ||
+              streql("NULL", str) || streql("", str)) {
+            return mrb_nil_value();
+          /* Check if it is a Boolean http://yaml.org/type/bool.html */
+          } else if (streql("true", str) || streql("True", str) || streql("TRUE", str) ||
+              streql("yes", str) || streql("Yes", str) || streql("YES", str) ||
+              streql("on", str) || streql("On", str) || streql("ON", str) ||
+              streql("y", str) || streql("Y", str)) {
+            return mrb_true_value();
+          } else if (streql("false", str) || streql("False", str) ||
+              streql("FALSE", str) || streql("off", str) || streql("Off", str) ||
+              streql("OFF", str) || streql("no", str) || streql("No", str) ||
+              streql("NO", str) || streql("n", str) || streql("N", str)) {
+            return mrb_false_value();
+          }
         }
 
         /* Check if it is a Fixnum */
@@ -179,28 +186,28 @@ node_to_value(mrb_state *mrb,
       /* Otherwise it is a String */
       return mrb_str_new(mrb, str, node->data.scalar.length);
     }
-    
+
     case YAML_SEQUENCE_NODE:
     {
       /* Sequences are arrays in Ruby */
       mrb_value result = mrb_ary_new(mrb);
       yaml_node_item_t *item;
-      
+
       int ai = mrb_gc_arena_save(mrb);
-      
+
       for (item = node->data.sequence.items.start;
         item < node->data.sequence.items.top; item++)
       {
         yaml_node_t *child_node = yaml_document_get_node(document, *item);
         mrb_value child = node_to_value(mrb, document, child_node);
-        
+
         mrb_ary_push(mrb, result, child);
         mrb_gc_arena_restore(mrb, ai);
       }
-      
+
       return result;
     }
-    
+
     case YAML_MAPPING_NODE:
     {
       /* Mappings are hashes in Ruby */
@@ -209,36 +216,49 @@ node_to_value(mrb_state *mrb,
       yaml_node_t *value_node;
       yaml_node_pair_t *pair;
       mrb_value key, value;
-      
+
       int ai = mrb_gc_arena_save(mrb);
-      
+
       for (pair = node->data.mapping.pairs.start;
         pair < node->data.mapping.pairs.top; pair++)
       {
         key_node = yaml_document_get_node(document, pair->key);
         value_node = yaml_document_get_node(document, pair->value);
-        
-        key = node_to_value(mrb, document, key_node);
+
+        key = node_to_value_key(mrb, document, key_node);
         value = node_to_value(mrb, document, value_node);
-        
+
         mrb_hash_set(mrb, result, key, value);
         mrb_gc_arena_restore(mrb, ai);
       }
-      
+
       return result;
     }
-    
+
     default:
       return mrb_nil_value();
   }
 }
 
+mrb_value
+node_to_value_key(mrb_state *mrb,
+  yaml_document_t *document, yaml_node_t *node)
+{
+  return node_to_value_with_aliases(mrb, document, node, 0);
+}
+
+mrb_value
+node_to_value(mrb_state *mrb,
+  yaml_document_t *document, yaml_node_t *node)
+{
+  return node_to_value_with_aliases(mrb, document, node, 1);
+}
 
 int value_to_node(mrb_state *mrb,
   yaml_document_t *document, mrb_value value)
 {
   int node;
-  
+
   switch (mrb_type(value))
   {
     case MRB_TT_ARRAY:
@@ -246,62 +266,67 @@ int value_to_node(mrb_state *mrb,
       mrb_int len = mrb_ary_len(mrb, value);
       mrb_int i;
       int ai = mrb_gc_arena_save(mrb);
-      
+
       node = yaml_document_add_sequence(document, NULL,
         YAML_ANY_SEQUENCE_STYLE);
-      
+
       for (i = 0; i < len; i++)
       {
         mrb_value child = mrb_ary_ref(mrb, value, i);
         int child_node = value_to_node(mrb, document, child);
-        
+
         /* Add the child to the sequence */
         yaml_document_append_sequence_item(document, node, child_node);
         mrb_gc_arena_restore(mrb, ai);
       }
-      
+
       break;
     }
-    
+
     case MRB_TT_HASH:
     {
       /* Iterating a list of keys is slow, but it only
        * requires use of the interface defined in `hash.h`.
        */
-      
+
       mrb_value keys = mrb_hash_keys(mrb, value);
       mrb_int len = mrb_ary_len(mrb, keys);
       mrb_int i;
       int ai = mrb_gc_arena_save(mrb);
-      
+
       node = yaml_document_add_mapping(document, NULL,
         YAML_ANY_MAPPING_STYLE);
-      
+
       for (i = 0; i < len; i++)
       {
         mrb_value key = mrb_ary_ref(mrb, keys, i);
         mrb_value child = mrb_hash_get(mrb, value, key);
-        
+
         int key_node = value_to_node(mrb, document, key);
         int child_node = value_to_node(mrb, document, child);
-        
+
         /* Add the key/value pair to the mapping */
         yaml_document_append_mapping_pair(document, node,
           key_node, child_node);
         mrb_gc_arena_restore(mrb, ai);
       }
-      
+
       break;
     }
-    
+
     default:
     {
-      /* Equivalent to `obj = obj#to_s` */
-      value = mrb_obj_as_string(mrb, value);
-      
+      if (mrb_nil_p(value)) {
+        /* http://yaml.org/type/null.html
+           Canonical form */
+        value = mrb_str_new_cstr(mrb, "~");
+      } else {
+        /* Equivalent to `obj = obj#to_s` */
+        value = mrb_obj_as_string(mrb, value);
+      }
       /* Fallthrough */
     }
-    
+
     case MRB_TT_STRING:
     {
       yaml_char_t *value_chars = (unsigned char *) RSTRING_PTR(value);
@@ -310,7 +335,7 @@ int value_to_node(mrb_state *mrb,
       break;
     }
   }
-  
+
   return node;
 }
 

--- a/src/yaml.c
+++ b/src/yaml.c
@@ -329,9 +329,15 @@ int value_to_node(mrb_state *mrb,
 
     case MRB_TT_STRING:
     {
+      yaml_scalar_style_t style = YAML_ANY_SCALAR_STYLE;
+      if (RSTRING_LEN(value) == 0) {
+        /* If the String is empty, it may be reloaded as a nil instead of an
+         * empty string, to avoid that place a quoted string instead */
+        style = YAML_SINGLE_QUOTED_SCALAR_STYLE;
+      }
       yaml_char_t *value_chars = (unsigned char *) RSTRING_PTR(value);
       node = yaml_document_add_scalar(document, NULL,
-        value_chars, RSTRING_LEN(value), YAML_ANY_SCALAR_STYLE);
+        value_chars, RSTRING_LEN(value), style);
       break;
     }
   }

--- a/src/yaml.c
+++ b/src/yaml.c
@@ -1,5 +1,6 @@
 
 #include <stdio.h>
+#include <string.h>
 #include <yaml.h>
 #include <mruby.h>
 #include <mruby/compile.h>
@@ -152,8 +153,17 @@ node_to_value(mrb_state *mrb,
       dd = strtod(str, &endptr);
       if (str != endptr && *endptr == '\0')
         return mrb_float_value(mrb, dd);
-      
-      /* Otherwise it is a String */      
+
+      /* Check if it is a Boolean */
+      if (strcmp("true", str) == 0)
+        return mrb_true_value();
+      else if (strcmp("false", str) == 0)
+        return mrb_false_value();
+      /* Check if it is a nil */
+      else if (strcmp("nil", str) == 0)
+        return mrb_nil_value();
+
+      /* Otherwise it is a String */
       return mrb_str_new(mrb, str, node->data.scalar.length);
     }
     

--- a/test/yaml.rb
+++ b/test/yaml.rb
@@ -88,6 +88,12 @@ assert('YAML load combo') do
 	actual == expected
 end
 
+assert('YAML load all') do
+	actual = YAML.load("y: 1\nn: 2\nnull: 3\n~: 4")
+	expected = { 'y' => 1, 'n' => 2, 'null' => 3, nil => 4 }
+	assert_equal expected, actual
+end
+
 assert('YAML load multi-byte') do
 	actual = YAML.load("bar: ばー\nfoo: ふー")
 	expected = {'foo' => 'ふー', 'bar' => 'ばー'}
@@ -167,7 +173,7 @@ assert('YAML dump mapping') do
 end
 
 assert('YAML dump combo') do
-	expected = {'foo' => [1, 2, 3, nil, true], 'bar' => 'baz', 'harf' => false }
+	expected = { 'foo' => [1, 2, 3, nil, true], 'bar' => 'baz', 'harf' => false, nil => true }
 	actual = YAML.load(YAML.dump(expected))
 	actual == expected
 end

--- a/test/yaml.rb
+++ b/test/yaml.rb
@@ -173,9 +173,14 @@ assert('YAML dump mapping') do
 end
 
 assert('YAML dump combo') do
-	expected = { 'foo' => [1, 2, 3, nil, true], 'bar' => 'baz', 'harf' => false, nil => true }
+	expected = {
+		'foo' => [1, 2, 3, nil, true],
+		'bar' => 'baz',
+		'harf' => false,
+		nil => ""
+	}
 	actual = YAML.load(YAML.dump(expected))
-	actual == expected
+	assert_equal expected, actual
 end
 
 assert('YAML dump multi-byte') do

--- a/test/yaml.rb
+++ b/test/yaml.rb
@@ -2,31 +2,74 @@
 # YAML::load
 
 assert('YAML load empty') do
-	YAML.load('') == false
+	YAML.load('') == nil
 end
 
 assert('YAML load true') do
-	YAML.load('true') == true
+	YAML.load('true') == true &&
+	YAML.load('True') == true &&
+	YAML.load('TRUE') == true &&
+	YAML.load('yes') == true &&
+	YAML.load('Yes') == true &&
+	YAML.load('YES') == true &&
+	YAML.load('on') == true &&
+	YAML.load('On') == true &&
+	YAML.load('ON') == true &&
+	YAML.load('y') == true &&
+	YAML.load('Y') == true
 end
 
 assert('YAML load false') do
-	YAML.load('false') == false
+	YAML.load('false') == false &&
+	YAML.load('False') == false &&
+	YAML.load('FALSE') == false &&
+	YAML.load('off') == false &&
+	YAML.load('Off') == false &&
+	YAML.load('OFF') == false &&
+	YAML.load('no') == false &&
+	YAML.load('NO') == false &&
+	YAML.load('n') == false &&
+	YAML.load('N') == false
 end
 
-assert('YAML load nil') do
-	YAML.load('nil') == nil
+assert('YAML load null') do
+	YAML.load('nil') == nil &&
+	YAML.load('null') == nil &&
+	YAML.load('Null') == nil &&
+	YAML.load('NULL') == nil &&
+	YAML.load('~') == nil
 end
 
 assert('YAML load scalar') do
 	YAML.load('foo') == 'foo'
 end
 
+assert('YAML load true as string') do
+	YAML.load('"true"') == "true"
+end
+
+assert('YAML load false as string') do
+	YAML.load('"false"') == "false"
+end
+
+assert('YAML load nil as string') do
+	YAML.load('"nil"') == "nil"
+end
+
 assert('YAML load fixnum') do
 	YAML.load('5') == 5
 end
 
+assert('YAML load fixnum as string') do
+	YAML.load('"5"') == "5"
+end
+
 assert('YAML load float') do
 	YAML.load('5.5') == 5.5
+end
+
+assert('YAML load float as string') do
+	YAML.load('"5.5"') == "5.5"
 end
 
 assert('YAML load sequence') do
@@ -51,6 +94,52 @@ assert('YAML load multi-byte') do
 	actual == expected
 end
 
+# http://yaml.org/type/bool.html
+assert('YAML boolean mapping') do
+	actual = YAML.load(%(---
+canonical: y
+answer: NO
+logical: True
+option: on
+))
+	expected = { 'canonical' => true, 'answer' => false, 'logical' => true,
+							 'option' => true }
+	assert_equal expected, actual
+end
+
+# http://yaml.org/type/null.html
+assert('YAML load empty document') do
+	YAML.load('---') == nil
+end
+
+assert('YAML null mapping') do
+	actual = YAML.load(%(---
+# This mapping has four keys,
+# one has a value.
+empty:
+canonical: ~
+english: null
+~: null key
+))
+	expected = { 'empty' => nil, 'canonical' => nil,
+							 'english' => nil, nil => 'null key' }
+	assert_equal expected, actual
+end
+
+assert('YAML null sequence') do
+	actual = YAML.load(%(---
+# This sequence has five
+# entries, two have values.
+sparse:
+  - ~
+  - 2nd entry
+  -
+  - 4th entry
+  - Null
+ ))
+	expected = { 'sparse' => [nil, '2nd entry', nil, '4th entry', nil] }
+	assert_equal expected, actual
+end
 
 # YAML::dump
 
@@ -78,7 +167,7 @@ assert('YAML dump mapping') do
 end
 
 assert('YAML dump combo') do
-	expected = {'foo' => [1, 2, 3], 'bar' => 'baz'}
+	expected = {'foo' => [1, 2, 3, nil, true], 'bar' => 'baz', 'harf' => false }
 	actual = YAML.load(YAML.dump(expected))
 	actual == expected
 end

--- a/test/yaml.rb
+++ b/test/yaml.rb
@@ -5,6 +5,18 @@ assert('YAML load empty') do
 	YAML.load('') == false
 end
 
+assert('YAML load true') do
+	YAML.load('true') == true
+end
+
+assert('YAML load false') do
+	YAML.load('false') == false
+end
+
+assert('YAML load nil') do
+	YAML.load('nil') == nil
+end
+
 assert('YAML load scalar') do
 	YAML.load('foo') == 'foo'
 end
@@ -28,8 +40,8 @@ assert('YAML load mapping') do
 end
 
 assert('YAML load combo') do
-	actual = YAML.load("foo: [1, 2.2, 300]\nbar: baz")
-	expected = {'foo' => [1, 2.2, 300], 'bar' => 'baz'}
+	actual = YAML.load("foo: [1, 2.2, 300, true, nil]\nbar: baz\nharf: false")
+	expected = {'foo' => [1, 2.2, 300, true, nil], 'bar' => 'baz', 'harf' => false}
 	actual == expected
 end
 

--- a/test/yaml.rb
+++ b/test/yaml.rb
@@ -6,38 +6,55 @@ assert('YAML load empty') do
 end
 
 assert('YAML load true') do
-	YAML.load('true') == true &&
-	YAML.load('True') == true &&
-	YAML.load('TRUE') == true &&
-	YAML.load('yes') == true &&
-	YAML.load('Yes') == true &&
-	YAML.load('YES') == true &&
-	YAML.load('on') == true &&
-	YAML.load('On') == true &&
-	YAML.load('ON') == true &&
-	YAML.load('y') == true &&
-	YAML.load('Y') == true
+	assert_true YAML.load('true')
+	assert_true YAML.load('True')
+	assert_true YAML.load('TRUE')
+	if YAML::SUPPORT_BOOLEAN_YES
+		assert_true YAML.load('yes')
+		assert_true YAML.load('Yes')
+		assert_true YAML.load('YES')
+	end
+	if YAML::SUPPORT_BOOLEAN_ON
+		assert_true YAML.load('on')
+		assert_true YAML.load('On')
+		assert_true YAML.load('ON')
+	end
+	if YAML::SUPPORT_BOOLEAN_SHORTHAND_YES
+		assert_true YAML.load('y')
+		assert_true YAML.load('Y')
+	end
+	true
 end
 
 assert('YAML load false') do
-	YAML.load('false') == false &&
-	YAML.load('False') == false &&
-	YAML.load('FALSE') == false &&
-	YAML.load('off') == false &&
-	YAML.load('Off') == false &&
-	YAML.load('OFF') == false &&
-	YAML.load('no') == false &&
-	YAML.load('NO') == false &&
-	YAML.load('n') == false &&
-	YAML.load('N') == false
+	assert_false YAML.load('false')
+	assert_false YAML.load('False')
+	assert_false YAML.load('FALSE')
+	if YAML::SUPPORT_BOOLEAN_OFF
+		assert_false YAML.load('off')
+		assert_false YAML.load('Off')
+		assert_false YAML.load('OFF')
+	end
+	if YAML::SUPPORT_BOOLEAN_NO
+		assert_false YAML.load('no')
+		assert_false YAML.load('NO')
+	end
+	if YAML::SUPPORT_BOOLEAN_SHORTHAND_NO
+		assert_false YAML.load('n')
+		assert_false YAML.load('N')
+	end
+	true
 end
 
 assert('YAML load null') do
-	YAML.load('nil') == nil &&
-	YAML.load('null') == nil &&
-	YAML.load('Null') == nil &&
-	YAML.load('NULL') == nil &&
-	YAML.load('~') == nil
+	assert_equal nil, YAML.load('nil')
+	assert_equal nil, YAML.load('~')
+	if YAML::SUPPORT_NULL
+		assert_equal nil, YAML.load('null')
+		assert_equal nil, YAML.load('Null')
+		assert_equal nil, YAML.load('NULL')
+	end
+	true
 end
 
 assert('YAML load scalar') do
@@ -111,7 +128,8 @@ option: on
 	expected = { 'canonical' => true, 'answer' => false, 'logical' => true,
 							 'option' => true }
 	assert_equal expected, actual
-end
+end if YAML::SUPPORT_BOOLEAN_NO && YAML::SUPPORT_BOOLEAN_YES &&
+	YAML::SUPPORT_BOOLEAN_ON && YAML::SUPPORT_BOOLEAN_OFF
 
 # http://yaml.org/type/null.html
 assert('YAML load empty document') do
@@ -130,7 +148,7 @@ english: null
 	expected = { 'empty' => nil, 'canonical' => nil,
 							 'english' => nil, nil => 'null key' }
 	assert_equal expected, actual
-end
+end if YAML::SUPPORT_NULL
 
 assert('YAML null sequence') do
 	actual = YAML.load(%(---
@@ -145,7 +163,7 @@ sparse:
  ))
 	expected = { 'sparse' => [nil, '2nd entry', nil, '4th entry', nil] }
 	assert_equal expected, actual
-end
+end if YAML::SUPPORT_NULL
 
 # YAML::dump
 


### PR DESCRIPTION
YAML should now be able to load true, false and nil

``` yaml

---
foo: true
bar: false
baz: nil
```

Result:

``` ruby
{
  "foo" => true,
  "bar" => false,
  "baz" => nil
}
```
