### PR TITLE
Minor fixes for building on MSVC2010

### DIFF
--- a/src/yaml.c
+++ b/src/yaml.c
@@ -304,7 +304,7 @@ int value_to_node(mrb_state *mrb,
   {
     case MRB_TT_ARRAY:
     {
-      mrb_int len = mrb_ary_len(mrb, value);
+      mrb_int len = RARRAY_LEN(value);
       mrb_int i;
       int ai = mrb_gc_arena_save(mrb);
 
@@ -331,7 +331,7 @@ int value_to_node(mrb_state *mrb,
        */
 
       mrb_value keys = mrb_hash_keys(mrb, value);
-      mrb_int len = mrb_ary_len(mrb, keys);
+      mrb_int len = RARRAY_LEN(keys);
       mrb_int i;
       int ai = mrb_gc_arena_save(mrb);
 

--- a/src/yaml.c
+++ b/src/yaml.c
@@ -7,7 +7,7 @@
 #include <mruby/string.h>
 #include <mruby/array.h>
 #include <mruby/hash.h>
-#include <inttypes.h>
+#include <stdint.h>
 #include <errno.h>
 
 #if defined(_MSC_VER)
@@ -371,12 +371,13 @@ int value_to_node(mrb_state *mrb,
     case MRB_TT_STRING:
     {
       yaml_scalar_style_t style = YAML_ANY_SCALAR_STYLE;
+      yaml_char_t *value_chars;
       if (RSTRING_LEN(value) == 0) {
         /* If the String is empty, it may be reloaded as a nil instead of an
          * empty string, to avoid that place a quoted string instead */
         style = YAML_SINGLE_QUOTED_SCALAR_STYLE;
       }
-      yaml_char_t *value_chars = (unsigned char *) RSTRING_PTR(value);
+      value_chars = (unsigned char *) RSTRING_PTR(value);
       node = yaml_document_add_scalar(document, NULL,
         value_chars, RSTRING_LEN(value), style);
       break;


### PR DESCRIPTION
replaced unnecessary `intense.h` in favor of more compact `stdint.h`; also, `inttypes.h` is not available on MSVC2010 (and earlier)
