### PR TITLE
Use the same behavior as CRuby for shorthands

### DIFF
--- a/src/yaml.c
+++ b/src/yaml.c
@@ -26,7 +26,7 @@
 #  define MRUBY_YAML_BOOLEAN_YES 1
 #endif
 #ifndef MRUBY_YAML_BOOLEAN_SHORTHAND_YES
-#  define MRUBY_YAML_BOOLEAN_SHORTHAND_YES 1
+#  define MRUBY_YAML_BOOLEAN_SHORTHAND_YES 0
 #endif
 #ifndef MRUBY_YAML_BOOLEAN_OFF
 #  define MRUBY_YAML_BOOLEAN_OFF 1
@@ -35,7 +35,7 @@
 #  define MRUBY_YAML_BOOLEAN_NO 1
 #endif
 #ifndef MRUBY_YAML_BOOLEAN_SHORTHAND_NO
-#  define MRUBY_YAML_BOOLEAN_SHORTHAND_NO 1
+#  define MRUBY_YAML_BOOLEAN_SHORTHAND_NO 0
 #endif
 
 void mrb_mruby_yaml_gem_init(mrb_state *mrb);


### PR DESCRIPTION
In CRuby,

```rb
YAML.load("n: n\ny: y") #=> {"n"=>"n", "y"=>"y"}
```

In mruby,

```rb
YAML.load("n: n\ny: y") #=> {"n"=>false, "y"=>true}
```

I think this is very problematic when porting existing library to mruby.