### PR TITLE
Merge hone/mruby-yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 #### YAML gem for [mruby](https://github.com/mruby/mruby)
 
-mruby-yaml wraps [libyaml](http://pyyaml.org/wiki/LibYAML) and therefore complies with the YAML 1.1 standard. File IO is not supported, as this would create a dependency on other mruby gems.
+mruby-yaml wraps [libyaml](https://pyyaml.org/wiki/LibYAML) and therefore complies with the YAML 1.1 standard. File IO is not supported, as this would create a dependency on other mruby gems.
 
 ### Defines
 | Name                             | Default | Description                    |

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -6,4 +6,45 @@ MRuby::Gem::Specification.new('mruby-yaml') do |spec|
 	spec.homepage = 'https://github.com/AndrewBelt/mruby-yaml'
 	
 	spec.linker.libraries << 'yaml'
+  require 'open3'
+
+  yaml_dir = "#{build_dir}/yaml-0.1.5"
+
+  def run_command env, command
+    STDOUT.sync = true
+    puts "build: [exec] #{command}"
+    Open3.popen2e(env, command) do |stdin, stdout, thread|
+      print stdout.read
+      fail "#{command} failed" if thread.value != 0
+    end
+  end
+
+  FileUtils.mkdir_p build_dir
+
+  if ! File.exists? yaml_dir
+    Dir.chdir(build_dir) do
+      e = {}
+      run_command e, 'curl http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz | tar -xzv'
+      run_command e, "mkdir #{yaml_dir}/build"
+    end
+  end
+
+  if ! File.exists? "#{yaml_dir}/libyaml.a"
+    Dir.chdir yaml_dir do
+      e = {
+        'CC' => "#{spec.build.cc.command} #{spec.build.cc.flags.join(' ')}",
+        'CXX' => "#{spec.build.cxx.command} #{spec.build.cxx.flags.join(' ')}",
+        'LD' => "#{spec.build.linker.command} #{spec.build.linker.flags.join(' ')}",
+        'AR' => spec.build.archiver.command,
+        'PREFIX' => "#{yaml_dir}/build"
+      }
+
+      run_command e, "./configure --prefix=$PREFIX"
+      run_command e, "make"
+      run_command e, "make install"
+    end
+  end
+
+  spec.cc.include_paths << "#{yaml_dir}/build/include"
+  spec.linker.library_paths << "#{yaml_dir}/build/lib/"
 end

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -30,7 +30,7 @@ MRuby::Gem::Specification.new('mruby-yaml') do |spec|
     end
   end
 
-  if ! File.exists? "#{yaml_dir}/libyaml.a"
+  if ! File.exists? "#{yaml_dir}/build/lib/libyaml.a"
     Dir.chdir yaml_dir do
       e = {
         'CC' => "#{spec.build.cc.command} #{spec.build.cc.flags.join(' ')}",

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -26,7 +26,7 @@ MRuby::Gem::Specification.new('mruby-yaml') do |spec|
   if ! File.exists? yaml_dir
     Dir.chdir(build_dir) do
       e = {}
-      run_command e, "curl http://pyyaml.org/download/libyaml/yaml-#{yaml_version}.tar.gz | tar -xzv"
+      run_command e, "curl -L https://pyyaml.org/download/libyaml/yaml-#{yaml_version}.tar.gz | tar -xzv"
       run_command e, "mkdir #{yaml_dir}/build"
     end
   end

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -8,7 +8,8 @@ MRuby::Gem::Specification.new('mruby-yaml') do |spec|
 	spec.linker.libraries << 'yaml'
   require 'open3'
 
-  yaml_dir = "#{build_dir}/yaml-0.1.5"
+  yaml_version = "0.1.6"
+  yaml_dir = "#{build_dir}/yaml-#{yaml_version}"
 
   def run_command env, command
     STDOUT.sync = true
@@ -24,7 +25,7 @@ MRuby::Gem::Specification.new('mruby-yaml') do |spec|
   if ! File.exists? yaml_dir
     Dir.chdir(build_dir) do
       e = {}
-      run_command e, 'curl http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz | tar -xzv'
+      run_command e, "curl http://pyyaml.org/download/libyaml/yaml-#{yaml_version}.tar.gz | tar -xzv"
       run_command e, "mkdir #{yaml_dir}/build"
     end
   end

--- a/src/yaml.c
+++ b/src/yaml.c
@@ -391,8 +391,8 @@ void
 mrb_mruby_yaml_gem_init(mrb_state *mrb)
 {
   struct RClass *klass = mrb_define_module(mrb, "YAML");
-  mrb_define_class_method(mrb, klass, "load", mrb_yaml_load, ARGS_REQ(1));
-  mrb_define_class_method(mrb, klass, "dump", mrb_yaml_dump, ARGS_REQ(1));
+  mrb_define_class_method(mrb, klass, "load", mrb_yaml_load, MRB_ARGS_REQ(1));
+  mrb_define_class_method(mrb, klass, "dump", mrb_yaml_dump, MRB_ARGS_REQ(1));
 
   mrb_define_const(mrb, klass, "SUPPORT_NULL", mrb_bool_value(MRUBY_YAML_NULL));
   mrb_define_const(mrb, klass, "SUPPORT_BOOLEAN_ON", mrb_bool_value(MRUBY_YAML_BOOLEAN_ON));

--- a/src/yaml.c
+++ b/src/yaml.c
@@ -304,7 +304,7 @@ int value_to_node(mrb_state *mrb,
   {
     case MRB_TT_ARRAY:
     {
-      mrb_int len = mrb_ary_len(mrb, value);
+      mrb_int len = RARRAY_LEN(value);
       mrb_int i;
       int ai = mrb_gc_arena_save(mrb);
 
@@ -331,7 +331,7 @@ int value_to_node(mrb_state *mrb,
        */
 
       mrb_value keys = mrb_hash_keys(mrb, value);
-      mrb_int len = mrb_ary_len(mrb, keys);
+      mrb_int len = RARRAY_LEN(keys);
       mrb_int i;
       int ai = mrb_gc_arena_save(mrb);
 


### PR DESCRIPTION
## Background
[home/mruby-yaml](https://github.com/hone/mruby-yaml) was a fork supporting static linking, and it had been official in mgem-list in the past https://github.com/mruby/mgem-list/pull/192.

However, this [AndrewBelt/mruby-yaml](https://github.com/mruby/mgem-list/pull/273) became official again in https://github.com/mruby/mgem-list/pull/273 because of missing https://github.com/hone/mruby-yaml/pull/3. Thus the official mruby-yaml mrbgem effectively dropped the backward compatibility at the moment.

## Changes
* Merge hone/mruby-yaml https://github.com/hone/mruby-yaml/compare/30fa3d2fa68d449a123a976a76a4a34c52ac3b7e...master
* Also merge https://github.com/hone/mruby-yaml/pull/3 to fix the build failure

@AndrewBelt What do you think about this?