### PR TITLE
Introduce MRUBY_YAML_USE_SYSTEM_LIBRARY

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -6,11 +6,8 @@ MRuby::Gem::Specification.new('mruby-yaml') do |spec|
   spec.homepage = 'https://github.com/mrbgems/mruby-yaml'
 
   spec.linker.libraries << 'yaml'
+
   require 'open3'
-
-  yaml_version = "0.2.2"
-  yaml_dir = "#{build_dir}/yaml-#{yaml_version}"
-
   def run_command env, command
     STDOUT.sync = true
     puts "build: [exec] #{command}"
@@ -20,42 +17,49 @@ MRuby::Gem::Specification.new('mruby-yaml') do |spec|
     end
   end
 
-  FileUtils.mkdir_p build_dir
+  use_system_library = ENV.fetch('MRUBY_YAML_USE_SYSTEM_LIBRARY', '') != ''
 
-  if ! File.exists? yaml_dir
-    Dir.chdir(build_dir) do
-      e = {}
-      run_command e, "curl -L https://pyyaml.org/download/libyaml/yaml-#{yaml_version}.tar.gz | tar -xzv"
-      run_command e, "mkdir #{yaml_dir}/build"
-    end
-  end
+  unless use_system_library
+    yaml_version = "0.2.1"
+    yaml_dir = "#{build_dir}/yaml-#{yaml_version}"
 
-  if ! File.exists? "#{yaml_dir}/build/lib/libyaml.a"
-    Dir.chdir yaml_dir do
-      e = {
-        'CC' => "#{spec.build.cc.command} #{spec.build.cc.flags.join(' ')}",
-        'CXX' => "#{spec.build.cxx.command} #{spec.build.cxx.flags.join(' ')}",
-        'LD' => "#{spec.build.linker.command} #{spec.build.linker.flags.join(' ')}",
-        'AR' => spec.build.archiver.command,
-        'PREFIX' => "#{yaml_dir}/build"
-      }
+    FileUtils.mkdir_p build_dir
 
-      configure_opts = %w(--prefix=$PREFIX --enable-static --disable-shared)
-      if build.kind_of?(MRuby::CrossBuild) && build.host_target && build.build_target
-        configure_opts += %W(--host #{spec.build.host_target} --build #{spec.build.build_target})
-        if %w(x86_64-w64-mingw32 i686-w64-mingw32).include?(build.host_target)
-          e["CFLAGS"] = "-DYAML_DECLARE_STATIC"
-          spec.cc.flags << "-DYAML_DECLARE_STATIC"
-        end
-        e['LD'] = "x86_64-w64-mingw32-ld #{spec.build.linker.flags.join(' ')}" if build.host_target == 'x86_64-w64-mingw32'
-        e['LD'] = "i686-w64-mingw32-ld #{spec.build.linker.flags.join(' ')}" if build.host_target == 'i686-w64-mingw32'
+    if ! File.exists? yaml_dir
+      Dir.chdir(build_dir) do
+        e = {}
+        run_command e, "curl -L https://pyyaml.org/download/libyaml/yaml-#{yaml_version}.tar.gz | tar -xzv"
+        run_command e, "mkdir #{yaml_dir}/build"
       end
-      run_command e, "./configure #{configure_opts.join(" ")}"
-      run_command e, "make"
-      run_command e, "make install"
     end
-  end
 
-  spec.cc.include_paths << "#{yaml_dir}/build/include"
-  spec.linker.library_paths << "#{yaml_dir}/build/lib/"
+    if ! File.exists? "#{yaml_dir}/build/lib/libyaml.a"
+      Dir.chdir yaml_dir do
+        e = {
+          'CC' => "#{spec.build.cc.command} #{spec.build.cc.flags.join(' ')}",
+          'CXX' => "#{spec.build.cxx.command} #{spec.build.cxx.flags.join(' ')}",
+          'LD' => "#{spec.build.linker.command} #{spec.build.linker.flags.join(' ')}",
+          'AR' => spec.build.archiver.command,
+          'PREFIX' => "#{yaml_dir}/build"
+        }
+
+        configure_opts = %w(--prefix=$PREFIX --enable-static --disable-shared)
+        if build.kind_of?(MRuby::CrossBuild) && build.host_target && build.build_target
+          configure_opts += %W(--host #{spec.build.host_target} --build #{spec.build.build_target})
+          if %w(x86_64-w64-mingw32 i686-w64-mingw32).include?(build.host_target)
+            e["CFLAGS"] = "-DYAML_DECLARE_STATIC"
+            spec.cc.flags << "-DYAML_DECLARE_STATIC"
+          end
+          e['LD'] = "x86_64-w64-mingw32-ld #{spec.build.linker.flags.join(' ')}" if build.host_target == 'x86_64-w64-mingw32'
+          e['LD'] = "i686-w64-mingw32-ld #{spec.build.linker.flags.join(' ')}" if build.host_target == 'i686-w64-mingw32'
+        end
+        run_command e, "./configure #{configure_opts.join(" ")}"
+        run_command e, "make"
+        run_command e, "make install"
+      end
+    end
+
+    spec.cc.include_paths << "#{yaml_dir}/build/include"
+    spec.linker.library_paths << "#{yaml_dir}/build/lib/"
+  end
 end

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -20,7 +20,7 @@ MRuby::Gem::Specification.new('mruby-yaml') do |spec|
   use_system_library = ENV.fetch('MRUBY_YAML_USE_SYSTEM_LIBRARY', '') != ''
 
   unless use_system_library
-    yaml_version = "0.2.1"
+    yaml_version = "0.2.2"
     yaml_dir = "#{build_dir}/yaml-#{yaml_version}"
 
     FileUtils.mkdir_p build_dir


### PR DESCRIPTION
Statically linking a dependent library improves the general deployability of the generated executable, but not so useful when you deploy the executable to only a specific environment, and locally building the library increases the build time and object size. So I want an option to have mruby linked to the library provided by the system.

This patch introduces the MRUBY_YAML_USE_SYSTEM_LIBRARY environment variable to control whether libyaml is built locally or linked to the system-provided one.

I think using an environment variable this way is not ideal as all the build targets built at the same time must share the configuration. However, mruby's build system does not yet provide any means of passing build configuration to mrbgem.