### PR TITLE
Made libyaml into a submodule and now build from that.

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -2,6 +2,12 @@ name: ubuntu
 on: [push, pull_request]
 jobs:
   gcc:
+    env:
+      # 'set-env' has been disabled by default because it's a
+      # potential security issue.  See https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/.
+      # We re-enable it here for now because the problem does not
+      # appear to affect us.
+      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     runs-on: ubuntu-latest
     steps:
       - name: Install libraries

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "third_party/libyaml"]
+	path = third_party/libyaml
+	url = https://github.com/yaml/libyaml.git

--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ else
 end
 ```
 
+### Getting libyaml
+
+If you have a compiled version of `libyaml` available on your system, you can use it by setting the environment variable `MRUBY_YAML_USE_SYSTEM_LIBRARY` to a non-empty value and ensuring your compiler can find the library.
+
+Otherwise, Rake will attempt to compile it from sources obtained from the offical `libyaml` GitHub repository.  This requires that you have `autoconf` installed.
+
+
 ### Documentation
 
 #### `YAML.load(yaml_str)`


### PR DESCRIPTION
Also added the configure scripts in a tarball so that the user does
not need to have autoconf installed and included the tool used to
generate this tarball.  (These files are included in the official
source distribution of libyaml but are not in the git repository.)

And made an attempt at fixing the CI configuration.  I have zero
experience with Github's CI so this is a crapshoot.