### PR TITLE
Update mruby version for GitHub Actions

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           fetch-depth: 10
       - name: Clone mruby
-        run: git clone --depth=1 --branch=2.0.1 https://github.com/mruby/mruby
+        run: git clone --depth=1 --branch=3.2.0 https://github.com/mruby/mruby
       - name: Build
         run: cd mruby && make all
       - name: Test


### PR DESCRIPTION
Update mruby in GitHub Actions to the latest version, 3.2.0, and make sure CI is not broken.