### PR TITLE
Check with multiple mruby versions

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -2,19 +2,35 @@ name: ubuntu
 on: [push, pull_request]
 jobs:
   gcc:
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '2.0.1'
+          - '2.1.2'
+          - '3.0.0'
+          - '3.1.0'
+          - '3.2.0'
     env:
-      MRUBY_BUILD: ../.github/build_config.rb
+      MRUBY_CONFIG: ../.github/build_config.rb
     runs-on: ubuntu-latest
     steps:
       - name: Install libraries
         run: |
           sudo apt-get install rake bison git gperf libonig-dev
       - name: Checkout
-        uses: actions/checkout@v1.0.0
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 10
+          submodules: true
       - name: Clone mruby
-        run: git clone --depth=1 --branch=2.0.1 https://github.com/mruby/mruby
+        run: git clone --depth=1 --branch=${{ matrix.version }} https://github.com/mruby/mruby
+      - name: Workaround for Ruby 3.0 build failure
+        if: ${{ matrix.version == '2.0.1' }}
+        run: |
+          # See also:
+          # https://github.com/mruby/mruby/commit/26e6e75ba6a59bc77c80a6ce5d207626cfed91a6
+          # https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/
+          sed -i -E 's@, opts$@@' mruby/Rakefile
       - name: Build
         run: cd mruby && make all
       - name: Test


### PR DESCRIPTION
- Support multiple mruby versions
  - `2.0.1`
  - `2.1.2`
  - `3.0.0`
  - `3.1.0`
  - `3.2.0`
- Workaround for mruby 2.0.1 build failure on Ruby 3.0 or higher
  - Ruby 3.0 a method delegating all arguments must explicitly delegate keyword arguments in addition to positional arguments.
  - Fixed in mruby with the following commit: https://github.com/mruby/mruby/commit/26e6e75ba6a59bc77c80a6ce5d207626cfed91a6
  - Where to apply monkey patch: https://github.com/mruby/mruby/blob/2.0.1/Rakefile#L37-L39
  - See also: https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/
- Update `actions/checkout@v1.0.0` to `actions/checkout@v4`
  - Remove fetch-depth option
  - Add submodules option
- Change `${MRUBY_BUILD}` to `${MRUBY_CONFIG}`
  - Display mruby-yaml in mruby build summary
- GitHub Actions Log
  - https://github.com/takumin/mruby-yaml/actions/runs/6678302036